### PR TITLE
Introduce CTest and improve test structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run unit tests
-        run: ./build/tests/test_control
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_C_STANDARD 99)
 
 add_compile_options(-Wall -Wextra -Werror)
 
+enable_testing()
+
 add_subdirectory(hal)
 add_subdirectory(domain)
 add_subdirectory(app)

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN rm -rf build && cmake -S . -B build
 RUN cmake --build build --config Release
 
 # 5. Comando por defecto: ejecutar tests
-CMD ["./build/tests/test_control"]
+CMD ["ctest", "--test-dir", "build", "--output-on-failure"]

--- a/README.md
+++ b/README.md
@@ -1,35 +1,177 @@
 # Embedded Template
 
-Plantilla base para proyectos de firmware con arquitectura limpia,
-orientada a calidad profesional, testabilidad y mantenimiento.
+Plantilla base para proyectos de firmware en C con **arquitectura limpia**, **tests unitarios** y **CI integrada**.
+
+Pensada como punto de partida reutilizable para proyectos embebidos (bare-metal, RTOS o Linux embebido), con foco en **calidad profesional**, **testabilidad** y **mantenibilidad**.
+
+---
+
+## Objetivos
+
+- Separar claramente **lógica de dominio** de **hardware**.
+- Facilitar **TDD en C** mediante Unity + CMock.
+- Disponer de un **build reproducible** (CMake + Docker).
+- Integrar **CI desde el primer día** (GitHub Actions + CTest).
+- Servir como plantilla realista para repositorios de firmware profesionales.
+
+---
 
 ## Arquitectura
 
 Estructura en capas:
 
-- `domain/`  
-  Lógica de negocio pura.  
-  - No depende de hardware  
-  - No conoce RTOS ni sistema operativo
+### `domain/`
+Lógica de negocio pura.
+- No depende de hardware  
+- No conoce RTOS ni sistema operativo
 
-- `hal/`  
-  Abstracción de hardware.  
-  - Define interfaces  
-  - No contiene lógica de negocio
+### `hal/`
+Abstracción de hardware.
+- Define interfaces (por ejemplo, `gpio_set`)
+- No contiene lógica de negocio
 
-- `app/`  
-  Capa de composición.  
-  - Conecta dominio con HAL
-  - Punto de entrada del sistema
+### `app/`
+Capa de composición.
+- Conecta dominio con la HAL real
+- Punto de entrada del sistema (`main()`)
 
-- `tests/`  
-  Tests unitarios del dominio y lógica.
+### `tests/`
+Tests unitarios del dominio y la lógica.
+- Unity como framework de test
+- CMock para aislamiento del hardware
+
+### Diagrama de arquitectura (simplificado)
+
+```text
+           +---------------------+
+           |        app/         |
+           |   (composition)     |
+           +----------+----------+
+                      |
+                      v
+           +---------------------+
+           |       domain/       |
+           |  (business logic)   |
+           +----------+----------+
+                      |
+              uses HAL interface
+                      |
+                      v
+           +---------------------+
+           |        hal/         |
+           | (hardware API only) |
+           +---------------------+
+
+           +---------------------+
+           |       tests/        |
+           |  Unity + CMock      |
+           +---------------------+
+```
+
+---
 
 ## Reglas de diseño
 
-- El dominio **no puede incluir headers de HAL**
-- El dominio **no conoce FreeRTOS, Linux ni ESP32**
-- HAL expone interfaces, no decisiones
-- `main()` solo orquesta, no piensa
+- El dominio **no puede incluir headers de HAL** (salvo a través de interfaces explícitas y controladas).
+- El dominio **no conoce FreeRTOS, Linux, ESP32, etc.**
+- La HAL expone **interfaces**, no decisiones de negocio.
+- `main()` solo **orquesta**, **no piensa**.
 
-Este repositorio es una base reutilizable para proyectos embebidos profesionales.
+Este repositorio sirve como base reutilizable para proyectos embebidos profesionales.
+
+---
+
+## Flujo de build y tests
+
+### 1. Local (desarrollo)
+
+```bash
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+- `cmake` genera el proyecto.
+- `cmake --build` compila aplicación y tests.
+- `ctest` ejecuta todos los tests registrados (Unity + CMock).
+
+---
+
+### 2. Docker (entorno reproducible)
+
+```bash
+docker build -t embedded-template .
+docker run --rm embedded-template
+```
+
+La imagen Docker:
+- Instala `build-essential` y `cmake`.
+- Configura el proyecto.
+- Compila el código.
+- Ejecuta los tests con `ctest`.
+
+Esto garantiza que el proyecto se construye y pasa los tests en un entorno controlado e independiente de la máquina de desarrollo.
+
+---
+
+### 3. CI (GitHub Actions)
+
+Workflow en:
+
+```
+.github/workflows/ci.yml
+```
+
+Ejecuta en cada `push` y `pull_request`:
+
+```bash
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+---
+
+## Tecnologías utilizadas
+
+- Lenguaje: C (C99)
+- Arquitectura: domain / HAL / app
+- Tests unitarios: Unity
+- Mocks: CMock
+- Build system: CMake + CTest
+- Entorno reproducible: Docker
+- CI: GitHub Actions
+
+---
+
+## Problemas que resuelve este template
+
+- **Lógica de negocio mezclada con drivers**  
+  → El dominio vive en `domain/` y no conoce registros ni pines.
+
+- **Tests inexistentes o difíciles de ejecutar**  
+  → Tests ejecutables con `ctest`, usando Unity + CMock.
+
+- **“En mi máquina funciona”**  
+  → Docker y CI garantizan reproducibilidad.
+
+- **Repositorios sin estructura clara**  
+  → Arquitectura y pipeline definidos desde el primer commit.
+
+---
+
+## Cómo extender el template
+
+### Añadir un nuevo módulo de dominio
+- Código en `domain/`
+- Tests en `tests/` usando `add_unity_test(...)`
+
+### Añadir una nueva HAL o implementación de hardware
+- Interfaces en `hal/`
+- Implementación concreta en `app/` o en un módulo HAL específico
+
+### Añadir más tests
+- Crear ficheros `test_*.c` en `tests/`
+- Registrar los tests en `tests/CMakeLists.txt`
+
+---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,3 +18,8 @@ target_sources(test_control PRIVATE
     ${PROJECT_SOURCE_DIR}/external/Unity/src/unity.c
     ${PROJECT_SOURCE_DIR}/external/CMock/src/cmock.c
 )
+
+add_test(
+    NAME test_control
+    COMMAND test_control
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,25 +1,45 @@
-add_executable(test_control
-    test_control.c
-    mocks/Mockgpio.c
-)
+# Librería común para todos los tests: Unity + CMock + dominio
 
-target_include_directories(test_control PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/mocks
-    ${PROJECT_SOURCE_DIR}/external/Unity/src
-    ${PROJECT_SOURCE_DIR}/external/CMock/src
-)
-
-target_link_libraries(test_control
-    domain
-)
-
-target_sources(test_control PRIVATE
+set(TEST_SUPPORT_SOURCES
     ${PROJECT_SOURCE_DIR}/external/Unity/src/unity.c
     ${PROJECT_SOURCE_DIR}/external/CMock/src/cmock.c
 )
 
-add_test(
-    NAME test_control
-    COMMAND test_control
+add_library(test_support STATIC
+    ${TEST_SUPPORT_SOURCES}
+)
+
+target_include_directories(test_support PUBLIC
+    ${PROJECT_SOURCE_DIR}/external/Unity/src
+    ${PROJECT_SOURCE_DIR}/external/CMock/src
+)
+
+# Los tests necesitan el dominio (que ya depende de hal)
+target_link_libraries(test_support PUBLIC
+    domain
+)
+
+# Pequeño helper para crear tests Unity + CMock
+function(add_unity_test NAME)
+    add_executable(${NAME} ${ARGN})
+
+    target_link_libraries(${NAME} PRIVATE
+        test_support
+    )
+
+    target_include_directories(${NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks
+    )
+
+    add_test(
+        NAME ${NAME}
+        COMMAND ${NAME}
+    )
+endfunction()
+
+# Test actual: test_control
+add_unity_test(test_control
+    test_control.c
+    mocks/Mockgpio.c
 )


### PR DESCRIPTION
This PR integrates CTest as the standard test runner for the project and refactors the test CMake setup to improve clarity and scalability.

Tests can now be executed consistently in local builds, Docker and CI using CTest.
